### PR TITLE
Update rexml (3.2.6 -> 3.2.8)

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -11,11 +11,10 @@ GEM
     eventmachine (1.2.7)
     ffi (1.15.5)
     forwardable-extended (2.6.0)
-    google-protobuf (3.24.0-arm64-darwin)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.2)
+    jekyll (4.3.3)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -38,8 +37,8 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
       rubyzip (>= 1.3.0, < 3.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (2.2.0)
+      sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
@@ -60,12 +59,14 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.6)
-    rouge (4.1.3)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rouge (3.30.0)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
-    sass-embedded (1.64.2-arm64-darwin)
-      google-protobuf (~> 3.23)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.4.2)
@@ -73,9 +74,10 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
 
 DEPENDENCIES
-  jekyll (~> 4.3)
+  jekyll (~> 4.3.2)
   jekyll-include-cache
   jekyll-remote-theme
   jekyll-seo-tag


### PR DESCRIPTION
This PR resolves an issue picked up by Dependabot detailing a vulnerability in the Ruby gem "REXML" - an XML toolkit for Ruby. Updates from `3.2.6` to `3.2.8`. More info can be found [here](https://nvd.nist.gov/vuln/detail/CVE-2024-35176).

The jekyll site was tested locally after updates with no detectable issues.