### PR TITLE
Security patch

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -9,3 +9,8 @@ gem "jekyll", "~> 4.3.2"
 gem "jekyll-remote-theme"
 gem "jekyll-seo-tag"
 gem "jekyll-include-cache"
+
+# Pin transitive deps addressed by ruby-advisory-db / Dependabot
+gem "addressable", ">= 2.9.0"
+gem "rexml", ">= 3.3.9"
+gem "webrick", ">= 1.8.2"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -10,7 +10,7 @@ gem "jekyll-remote-theme"
 gem "jekyll-seo-tag"
 gem "jekyll-include-cache"
 
-# Pin transitive deps addressed by ruby-advisory-db / Dependabot
+# Seurity updates
 gem "addressable", ">= 2.9.0"
 gem "rexml", ">= 3.3.9"
 gem "webrick", ">= 1.8.2"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.5)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     colorator (1.1.0)
     concurrent-ruby (1.2.2)
     em-websocket (0.5.3)
@@ -54,34 +54,36 @@ GEM
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.3)
+    public_suffix (5.1.1)
     rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.4.4)
     rouge (3.30.0)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
-    strscan (3.1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.4.2)
-    webrick (1.8.1)
+    webrick (1.9.2)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-25
 
 DEPENDENCIES
+  addressable (>= 2.9.0)
   jekyll (~> 4.3.2)
   jekyll-include-cache
   jekyll-remote-theme
   jekyll-seo-tag
   rake
+  rexml (>= 3.3.9)
+  webrick (>= 1.8.2)
 
 BUNDLED WITH
    2.4.18


### PR DESCRIPTION
Resolves security issues with `addressable`, `rexml`, and `webrick`. More info can be found [here](https://github.com/maize-genetics/breeder-genomics-hub/security/dependabot).