### PR TITLE
Bump `concurrent-ruby` to at least 1.3.7

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -11,6 +11,7 @@ gem "jekyll-seo-tag"
 gem "jekyll-include-cache"
 
 # Seurity updates
+gem "concurrent-ruby", ">= 1.3.7"
 gem "addressable", ">= 2.9.0"
 gem "rexml", ">= 3.3.9"
 gem "webrick", ">= 1.8.2"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     colorator (1.1.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.7)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -77,6 +77,7 @@ PLATFORMS
 
 DEPENDENCIES
   addressable (>= 2.9.0)
+  concurrent-ruby (>= 1.3.7)
   jekyll (~> 4.3.2)
   jekyll-include-cache
   jekyll-remote-theme


### PR DESCRIPTION
Updates `concurrent-ruby` to use at least version `1.3.7`. This is needed based on a [recently reported vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2026-54904).